### PR TITLE
fix: corrige bug de timezone na data do casamento

### DIFF
--- a/src/app/project/[projectId]/page.tsx
+++ b/src/app/project/[projectId]/page.tsx
@@ -33,6 +33,7 @@ export default function ProjectPage() {
         day: '2-digit',
         month: 'long',
         year: 'numeric',
+        timeZone: 'UTC',
       })
     : 'Data não definida';
 

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -26,7 +26,7 @@ export function Header() {
               </p>
               {project.weddingDate && (
                 <p className="text-sm text-gray-600">
-                  {new Date(project.weddingDate).toLocaleDateString('pt-BR')}
+                  {new Date(project.weddingDate).toLocaleDateString('pt-BR', { timeZone: 'UTC' })}
                 </p>
               )}
             </div>

--- a/src/components/projects/create-project-modal.tsx
+++ b/src/components/projects/create-project-modal.tsx
@@ -29,7 +29,7 @@ export function CreateProjectModal({ isOpen, onClose }: CreateProjectModalProps)
   const onSubmit = async (data: CreateProjectInput) => {
     const project = await createProject.mutateAsync({
       ...data,
-      weddingDate: weddingDate ? new Date(weddingDate) : null,
+      weddingDate: weddingDate ? new Date(weddingDate + 'T12:00:00.000Z') : null,
     });
 
     reset();


### PR DESCRIPTION
- Força uso de UTC ao salvar data (meio-dia UTC)
- Força exibição em UTC em todos os locais
- Garante que data selecionada = data exibida